### PR TITLE
Adds handling of multiple templ instances

### DIFF
--- a/example/controllers/home.js
+++ b/example/controllers/home.js
@@ -4,3 +4,7 @@ var app = require('cantina')
 controller.get('/', function (req, res, next) {
   res.render('index');
 });
+
+controller.get('/page', function (req, res, next) {
+  res.render('page');
+});

--- a/example/example.js
+++ b/example/example.js
@@ -6,5 +6,7 @@ app.boot(function (err) {
   // require('cantina-web');
   require('../');
 
+  app.loadTemplates(app.root + '/extraViews');
+
   app.start();
 });

--- a/example/extraViews/page.hbs
+++ b/example/extraViews/page.hbs
@@ -1,0 +1,2 @@
+<h2>Page</h2>
+<p>Welcome an the example page!</p>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "pause": "0.0.1",
     "href": "~0.1.1",
     "formidable": "~1.0.14",
-    "qs": "~0.6.5"
+    "qs": "~0.6.5",
+    "stac": "~0.0.12"
   },
   "devDependencies": {
     "mocha": "*",

--- a/plugins/templ-multi.js
+++ b/plugins/templ-multi.js
@@ -1,0 +1,79 @@
+var templ = require('templ')
+  , path = require('path')
+  , templStac = require('stac')();
+
+
+exports.addDir = function (dir, weight) {
+  var newTempl = templ(dir);
+  templStac.add(weight || 0, newTempl);
+};
+
+exports.middleware = function (req, res, next) {
+  res.render = function (p, context, options) {
+    var vars = res.vars
+      , success = false
+      , layoutName = 'layout'
+      , layout = null;
+
+    context || (context = res.vars);
+    options || (options = {});
+
+    // Find the default layout
+    if (typeof context.layout !== 'undefined') {
+      options.layout = context.layout;
+      delete context.layout;
+    }
+    if (options.layout) {
+      if (typeof options.layout === 'function') {
+        layout = options.layout;
+      }
+      else {
+        layoutName = options.layout;
+      }
+    }
+
+    if (options.layout !== false && !layout) {
+      templStac.forEach(function (middleware) {
+        layout || (layout = middleware._cache[path.sep + layoutName]);
+      });
+      options.layout = layout;
+    }
+
+    templStac.forEach(function (middleware) {
+
+      // Check if the template we're rendering is in this templ cache
+      if (middleware._cache[path.sep + p]) {
+
+        // Apply the middleware
+        middleware(req, res);
+
+        // Re-attach vars. The middleware just cleared them
+        res.vars = vars;
+
+        // Render
+        res.render.call(null, p, context, options);
+        success = true;
+      }
+    });
+
+    if (!success) {
+      throw new Error('template not found: ' + p)
+    }
+  };
+  res.renderStatus = function (status, p, context) {
+    if (typeof p === 'object') {
+      context = p;
+      p = null;
+    }
+    if (!p) p = 'status-' + status;
+    try {
+      res.render(p, context, {status: status});
+    }
+    catch (e) {
+      res.writeHead(status);
+      res.end();
+    }
+  };
+  res.vars = {};
+  next && next();
+};

--- a/plugins/views.js
+++ b/plugins/views.js
@@ -1,11 +1,12 @@
 var app = require('cantina')
   , path = require('path')
   , fs = require('fs')
+  , templMulti = require('./templ-multi')
   , conf
   , root;
 
-// Expose templ.
-app.templ = require('templ');
+// Expose Handlebars
+app.Handlebars = require('templ').handlebars;
 
 // Default conf.
 app.conf.add({
@@ -23,6 +24,11 @@ conf = app.conf.get('web:views');
 if (conf) {
   root = path.resolve(app.root, conf.root);
   if (fs.existsSync(root)) {
-    app.viewsHandler = app.templ(root);
+    templMulti.addDir(root);
   }
+  app.viewsHandler = templMulti.middleware;
 }
+
+app.loadTemplates = function (dir, weight) {
+  templMulti.addDir(dir, weight);
+};

--- a/test/basic.js
+++ b/test/basic.js
@@ -22,6 +22,18 @@ describe('basic test', function () {
       assert.equal(res.statusCode, 200);
       assert(res.headers['content-type'].match(/text\/html/));
       assert(res.body.indexOf('<h1>Example Site</h1>') > 0);
+      assert(res.body.indexOf('<h2>Home</h2>') > 0);
+      done();
+    });
+  });
+
+  it('GET /page from second template dir', function (done) {
+    request('http://localhost:3000/page', function (err, res, body) {
+      assert.ifError(err);
+      assert.equal(res.statusCode, 200);
+      assert(res.headers['content-type'].match(/text\/html/));
+      assert(res.body.indexOf('<h1>Example Site</h1>') > 0);
+      assert(res.body.indexOf('<h2>Page</h2>') > 0);
       done();
     });
   });


### PR DESCRIPTION
Not sure how to handle the API breakage since master is already at `3.1.0` - thoughts?

Changes:
- No more `app.templ` or `app.templ.handlebars` available.
- Adds `app.Handlebars` for access to the same instance templ uses
- To add additional view directories call `app.loadTemplates( dir, weight [optional] )`
